### PR TITLE
feat: add WhatsApp button component and improve UI

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,38 +1,38 @@
 import Footer from './components/pages/Footer'
 import Navbar from './components/pages/HomeNavbar'
-import { Button } from './components/ui/button'
 import Benefits from './pages/home/Benefits'
 import CategoryCarrousel from './pages/home/CategoryCarrousel'
 import FeaturedProducts from './pages/home/FeaturedProducts'
 import Testimonials from './pages/home/Testimonials'
+import ActiveBannerDesktop from '@/assets/images/banners/Desktop.webp'
+import ActiveBannerMobile from '@/assets/images/banners/Mobile.webp'
 
 function App() {
   return (
     <div className="flex min-h-screen flex-col">
       <Navbar />
       {/* Hero Section */}
-      <section className="w-full py-12 md:py-24 lg:py-32 bg-[url('/placeholder.svg?height=800&width=1600')] bg-cover bg-center relative">
-        <div className="absolute inset-0 bg-black/40"></div>
-        <div className="container mx-auto relative z-10 flex flex-col items-center gap-4 text-center">
-          <h1 className="text-3xl font-bold tracking-tighter text-white sm:text-5xl md:text-6xl">
-            Fresh From Farm to Your Table
-          </h1>
-          <p className="max-w-[700px] text-white md:text-xl">
-            Discover premium quality agricultural products sourced directly from local farmers.
-          </p>
-          <div className="flex flex-col gap-2 min-[400px]:flex-row">
-            <Button size="lg" className="button-primary">
-              Shop Now
-            </Button>
-            <Button size="lg" variant="secondary" className="">
-              Learn More
-            </Button>
-          </div>
-        </div>
-      </section>
+      <picture>
+        <source media="(max-width: 768px)" srcSet={ActiveBannerMobile} />
+        <source media="(min-width: 769px)" srcSet={ActiveBannerDesktop} />
+        <img
+          src={ActiveBannerDesktop}
+          alt="Banner publicitario"
+          className="w-full h-auto"
+          loading="lazy"
+        />
+      </picture>
+
+      {/* Categories Section */}
       <CategoryCarrousel />
+
+      {/* Featured Products Section */}
       <FeaturedProducts />
+
+      {/* Benefits Section */}
       <Benefits />
+
+      {/* Testimonials Section */}
       <Testimonials />
       <Footer />
     </div>

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -1,140 +1,91 @@
 import { createBrowserRouter } from 'react-router'
-import { MainLayout } from './layouts/MainLayout'
 import App from './App'
+
+// Layouts
+import { MainLayout } from './layouts/MainLayout'
 import AuthLayout from './layouts/AuthLayout'
-import LoginPage from './pages/auth/Login'
-import Register from './pages/auth/Register'
-import Profile from './pages/account/user/Profile'
 import AccountLayout from './layouts/AccountLayout'
-import ChangePassword from './pages/account/user/ChangePassword'
 import DashboardLayout from './layouts/DashboardLayout'
-import CategoriesDashboardPage from './pages/dashboard/categories'
-import UnitiesDashboardPage from './pages/dashboard/unities'
-import UsersDashboardPage from './pages/dashboard/users'
-import ForgotPasswordPage from './pages/auth/ForgotPassword'
-import CouponsDashboardPage from './pages/dashboard/coupons'
-import ProductsDashboardPage from './pages/dashboard/products'
-import ResetPasswordValidatePage from './pages/auth/ResetPasswordValidate'
-import ResetPasswordConfirmPage from './pages/auth/ResetPasswordConfirm'
+
+// Páginas públicas
 import ProductsPage from './pages/products'
 import ProductDetail from './pages/products/Detail'
 import CheckOutPage from './pages/checkout'
 import UserOrdersPage from './pages/orders'
+
+// Páginas auth
+import LoginPage from './pages/auth/Login'
+import Register from './pages/auth/Register'
+import ForgotPasswordPage from './pages/auth/ForgotPassword'
+import ResetPasswordValidatePage from './pages/auth/ResetPasswordValidate'
+import ResetPasswordConfirmPage from './pages/auth/ResetPasswordConfirm'
+
+// Páginas de cuenta
+import Profile from './pages/account/user/Profile'
+import ChangePassword from './pages/account/user/ChangePassword'
+
+// Páginas dashboard
+import DashboardIndex from './pages/dashboard'
+import UsersDashboardPage from './pages/dashboard/users'
+import CategoriesDashboardPage from './pages/dashboard/categories'
+import UnitiesDashboardPage from './pages/dashboard/unities'
+import ProductsDashboardPage from './pages/dashboard/products'
+import CouponsDashboardPage from './pages/dashboard/coupons'
 import OrdersPage from './pages/dashboard/orders'
-import DahsboardIndex from './pages/dashboard'
 
 export const Router = createBrowserRouter([
+  // 🌐 Rutas públicas
   {
     path: '/',
     element: <MainLayout />,
     errorElement: <div>404</div>,
     children: [
-      {
-        index: true,
-        element: <App />,
-      },
-      {
-        path: '/products',
-        element: <ProductsPage />,
-      },
-      {
-        path: '/products/:slug',
-        element: <ProductDetail />,
-      },
-      {
-        path: '/contacts',
-        element: <div>Contacts</div>,
-      },
-      {
-        path: '/checkout',
-        element: <CheckOutPage />,
-      },
-      {
-        path: '/privacy-policy',
-        element: <div>Privacy Policy</div>,
-      },
-      {
-        path: '/terms-and-conditions',
-        element: <div>Terms and Conditions</div>,
-      },
-      {
-        path: '/orders',
-        element: <UserOrdersPage />,
-      },
-      {
-        path: '/auth',
-        element: <AuthLayout />,
-        children: [
-          {
-            path: 'login',
-            element: <LoginPage />,
-          },
-          {
-            path: 'register',
-            element: <Register />,
-          },
-          {
-            path: 'forgot-password',
-            element: <ForgotPasswordPage />,
-          },
-          {
-            path: 'reset-password-validate',
-            element: <ResetPasswordValidatePage />,
-          },
-          {
-            path: 'reset-password-confirm/:code',
-            element: <ResetPasswordConfirmPage />,
-          },
-        ],
-      },
-      {
-        path: '/account',
-        element: <AccountLayout />,
-        children: [
-          {
-            path: 'profile',
-            element: <Profile />,
-          },
-          {
-            path: 'change-password',
-            element: <ChangePassword />,
-          },
-        ],
-      },
-      {
-        path: '/dashboard',
-        element: <DashboardLayout />,
-        children: [
-          {
-            index: true,
-            element: <DahsboardIndex />,
-          },
-          {
-            path: 'users',
-            element: <UsersDashboardPage />,
-          },
-          {
-            path: 'categories',
-            element: <CategoriesDashboardPage />,
-          },
-          {
-            path: 'unities',
-            element: <UnitiesDashboardPage />,
-          },
-          {
-            path: 'products',
-            element: <ProductsDashboardPage />,
-          },
-          {
-            path: 'coupons',
-            element: <CouponsDashboardPage />,
-          },
-          {
-            path: 'orders',
-            element: <OrdersPage />,
-          },
-        ],
-      },
+      { index: true, element: <App /> },
+      { path: 'products', element: <ProductsPage /> },
+      { path: 'products/:slug', element: <ProductDetail /> },
+      { path: 'checkout', element: <CheckOutPage /> },
+      { path: 'orders', element: <UserOrdersPage /> },
+      { path: 'contacts', element: <div>Contacts</div> },
+      { path: 'privacy-policy', element: <div>Privacy Policy</div> },
+      { path: 'terms-and-conditions', element: <div>Terms and Conditions</div> },
+    ],
+  },
+
+  // 🔐 Rutas de autenticación
+  {
+    path: '/auth',
+    element: <AuthLayout />,
+    children: [
+      { path: 'login', element: <LoginPage /> },
+      { path: 'register', element: <Register /> },
+      { path: 'forgot-password', element: <ForgotPasswordPage /> },
+      { path: 'reset-password-validate', element: <ResetPasswordValidatePage /> },
+      { path: 'reset-password-confirm/:code', element: <ResetPasswordConfirmPage /> },
+    ],
+  },
+
+  // 👤 Rutas de cuenta del usuario
+  {
+    path: '/account',
+    element: <AccountLayout />,
+    children: [
+      { path: 'profile', element: <Profile /> },
+      { path: 'change-password', element: <ChangePassword /> },
+    ],
+  },
+
+  // 📊 Rutas del dashboard
+  {
+    path: '/dashboard',
+    element: <DashboardLayout />,
+    children: [
+      { index: true, element: <DashboardIndex /> },
+      { path: 'users', element: <UsersDashboardPage /> },
+      { path: 'categories', element: <CategoriesDashboardPage /> },
+      { path: 'unities', element: <UnitiesDashboardPage /> },
+      { path: 'products', element: <ProductsDashboardPage /> },
+      { path: 'coupons', element: <CouponsDashboardPage /> },
+      { path: 'orders', element: <OrdersPage /> },
     ],
   },
 ])

--- a/src/components/blocks/WhatsAppBtn.tsx
+++ b/src/components/blocks/WhatsAppBtn.tsx
@@ -1,0 +1,19 @@
+import ExtendedTooltip from './ExtendedTooltip'
+import { Link } from 'react-router-dom'
+import WhatsAppIcon from '../icons/WhatsApp'
+
+function WhatsAppBtn() {
+  return (
+    <ExtendedTooltip content="Chatea con nosotros">
+      <Link
+        to={'https://wa.me/584122647923/'}
+        className="fixed bottom-4 right-4 z-10 cursor-pointer animate-bounce"
+        target="_blank"
+      >
+        <WhatsAppIcon className="w-10 h-10" fill="#25D366" />
+      </Link>
+    </ExtendedTooltip>
+  )
+}
+
+export default WhatsAppBtn

--- a/src/components/pages/dashboard/Sidebar.tsx
+++ b/src/components/pages/dashboard/Sidebar.tsx
@@ -25,17 +25,20 @@ import { ReactNode } from 'react'
 import { ModeToggle } from '@/components/mode-toggle'
 import LogoutBtn from '@/components/blocks/LogoutBtn'
 import { Separator } from '@/components/ui/separator'
+import { Badge } from '@/components/ui/badge'
+import { cn } from '@/lib/utils'
 
-type Props = {
+interface Props {
   user: User | null
 }
 
-type MenuItem = {
+interface MenuItem {
   name: string
   icon: ReactNode
   asLink: boolean
   path: string
   callBack?: () => void
+  isReady: boolean
 }
 
 const menuItems: MenuItem[] = [
@@ -44,59 +47,102 @@ const menuItems: MenuItem[] = [
     path: '/dashboard',
     icon: <SettingsIcon />,
     asLink: true,
+    isReady: true,
   },
   {
     name: 'Usuarios',
     path: '/dashboard/users',
     icon: <UsersIcon />,
     asLink: true,
+    isReady: true,
   },
   {
     name: 'Categorías',
     path: '/dashboard/categories',
     icon: <LayoutTemplateIcon />,
     asLink: true,
+    isReady: true,
   },
   {
     name: 'Unidades',
     path: '/dashboard/unities',
     icon: <RulerIcon />,
     asLink: true,
+    isReady: true,
   },
   {
     name: 'Productos',
     path: '/dashboard/products',
     icon: <PackageIcon />,
     asLink: true,
+    isReady: true,
   },
   {
     name: 'Cupones',
     path: '/dashboard/coupons',
     icon: <TagIcon />,
     asLink: true,
+    isReady: true,
   },
   {
     name: 'Ordenes',
     path: '/dashboard/orders',
     icon: <LayersIcon />,
     asLink: true,
+    isReady: true,
   },
   {
     name: 'Anuncios',
     path: '/dashboard/ads',
     icon: <GalleryVerticalIcon />,
     asLink: true,
+    isReady: false,
   },
 ]
 
-function AppSidebar({ user }: Props) {
+const activeClassName =
+  'font-bold bg-blue-300/20 dark:bg-blue-400/30 border-r-4 border-blue-600 transition hover:bg-blue-400/20 text-blue-500 dark:text-blue-500 hover:text-blue-700'
+
+function RenderItem({ item }: { item: MenuItem }) {
   const location = useLocation()
+
   const isActive = (currentPath: string, itemPath: string) => {
     return currentPath === itemPath
   }
-  const activeClassName =
-    'font-bold bg-blue-300/20 dark:bg-blue-400/30 border-r-4 border-blue-600 transition hover:bg-blue-400/20 text-blue-500 dark:text-blue-500 hover:text-blue-700'
 
+  return (
+    <SidebarMenuItem>
+      {item.asLink ? (
+        <SidebarMenuButton
+          asChild
+          className={cn(
+            'font-serif tracking-wide flex items-center gap-2 relative hover:bg-blue-300/20 text-black dark:text-white py-5',
+            isActive(location.pathname, item.path) && activeClassName,
+            !item.isReady &&
+              ' cursor-not-allowed bg-slate-100 dark:bg-gray-700/30 dark:text-gray-500 pointer-events-none'
+          )}
+        >
+          <Link to={item.path}>
+            {item.icon}
+            <span>{item.name}</span>
+            {!item.isReady && (
+              <Badge className="absolute right-2 text-gray-400" variant={'outline'}>
+                Pronto
+              </Badge>
+            )}
+          </Link>
+        </SidebarMenuButton>
+      ) : (
+        <SidebarMenuButton className="flex items-center gap-2">
+          {item.icon}
+          <span>{item.name}</span>
+        </SidebarMenuButton>
+      )}
+    </SidebarMenuItem>
+  )
+}
+
+function AppSidebar({ user }: Props) {
   return (
     <Sidebar>
       <SidebarContent className="bg-white dark:bg-black">
@@ -110,26 +156,7 @@ function AppSidebar({ user }: Props) {
             </SidebarMenuButton>
             <Separator />
             {menuItems.map((item, idx) => (
-              <SidebarMenuItem key={idx}>
-                {item.asLink ? (
-                  <SidebarMenuButton
-                    asChild
-                    className={`font-serif tracking-wide flex items-center gap-2 hover:bg-blue-300/20 text-black dark:text-white py-5 ${
-                      isActive(location.pathname, item.path) ? activeClassName : ''
-                    }`}
-                  >
-                    <Link to={item.path}>
-                      {item.icon}
-                      <span>{item.name}</span>
-                    </Link>
-                  </SidebarMenuButton>
-                ) : (
-                  <SidebarMenuButton className="flex items-center gap-2">
-                    {item.icon}
-                    <span>{item.name}</span>
-                  </SidebarMenuButton>
-                )}
-              </SidebarMenuItem>
+              <RenderItem key={idx} item={item} />
             ))}
           </SidebarMenu>
         </SidebarGroup>

--- a/src/layouts/AccountLayout.tsx
+++ b/src/layouts/AccountLayout.tsx
@@ -1,3 +1,4 @@
+import WhatsAppBtn from '@/components/blocks/WhatsAppBtn'
 import AppSidebar from '@/components/pages/account/Sidebar'
 import { SidebarProvider, SidebarTrigger } from '@/components/ui/sidebar'
 import { useAutoClearResponseStatus } from '@/hooks/useAutoClearResponseStatus'
@@ -11,7 +12,7 @@ function AccountLayout() {
   useAutoClearResponseStatus()
 
   return (
-    <section className="w-full h-full">
+    <section className="w-full h-full relative">
       <section className="grid grid-cols-[auto_1fr] grid-rows-[1fr] gap-y-[10px] gap-x-[10px] min-h-screen">
         <section className="">
           <SidebarProvider>
@@ -25,6 +26,7 @@ function AccountLayout() {
           <Outlet />
         </section>
       </section>
+      <WhatsAppBtn />
     </section>
   )
 }

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -5,6 +5,7 @@ import { Loader } from '@/components/ui/loader'
 import { getCurrentUser } from '@/actions/auth/getCurrentUser'
 import { useCartSyncAcrossTabs } from '@/hooks/useCartSyncAcrossTabs'
 import { UIUpdateModal } from '@/components/UIUpdateModal'
+import WhatsAppBtn from '@/components/blocks/WhatsAppBtn'
 
 export const MainLayout = () => {
   const setUser = useAuthStore((state) => state.setUser)
@@ -40,10 +41,12 @@ export const MainLayout = () => {
     )
   } else {
     return (
-      <>
+      <section className="relative">
         <UIUpdateModal />
         <Outlet />
-      </>
+
+        <WhatsAppBtn />
+      </section>
     )
   }
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,7 +5,7 @@ import { RouterProvider } from 'react-router'
 import { Router } from './Router.tsx'
 import { ThemeProvider } from '@/components/theme-provider'
 import { Toaster } from './components/ui/sonner.tsx'
-import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
+// import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 
 const queryClient = new QueryClient()
@@ -14,7 +14,7 @@ createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
       {/* The rest of your application */}
-      <ReactQueryDevtools initialIsOpen={false} />
+      {/* <ReactQueryDevtools initialIsOpen={false} /> */}
       <ThemeProvider defaultTheme="dark" storageKey="vite-ui-theme">
         <RouterProvider router={Router} />
         <Toaster richColors />

--- a/src/pages/cart/index.tsx
+++ b/src/pages/cart/index.tsx
@@ -17,6 +17,7 @@ import { Badge } from '@/components/ui/badge'
 import { CartItem } from '@/types/cart'
 import { getProductPrice } from '@/lib/getProductPrice'
 import ProductImage from '@/components/pages/products/ProductImage'
+import { cn } from '@/lib/utils'
 
 function RenderCartItem({ item }: { item: CartItem }) {
   const deleteItem = useCartStore((state) => state.deleteItem)
@@ -54,23 +55,18 @@ function RenderCartItem({ item }: { item: CartItem }) {
 }
 
 function RenderContinueButton({ allowed }: { allowed: boolean }) {
-  return allowed ? (
+  return (
     <Button
-      asChild
       size={'lg'}
+      asChild={allowed}
+      disabled={!allowed}
       variant={'outline'}
-      className="button-primary w-full uppercase cursor-pointer"
+      className={cn(
+        'button-primary w-full uppercase ',
+        allowed ? 'cursor-pointer' : 'cursor-not-allowed'
+      )}
     >
-      <Link to={'/checkout'}>Continuar</Link>
-    </Button>
-  ) : (
-    <Button
-      disabled
-      size={'lg'}
-      variant={'outline'}
-      className="button-primary w-full uppercase cursor-not-allowed"
-    >
-      Continuar
+      {allowed ? <Link to={'/checkout'}>Continuar</Link> : 'No hay productos'}
     </Button>
   )
 }
@@ -113,12 +109,12 @@ function CartPage() {
         </div>
         <SheetFooter>
           {!user && <p className="text-sm text-center">Debes iniciar sesión para continuar</p>}
-          <RenderContinueButton allowed={items.length > 1 || !!user} />
+          <RenderContinueButton allowed={items.length > 0} />
           <Button
             size={'lg'}
             variant={'outline'}
             onClick={clearCart}
-            disabled={items.length < 1}
+            disabled={items.length <= 0}
             className="bg-red-500 hover:bg-red-600 text-white dark:bg-red-500 dark:hover:bg-red-600 w-full uppercase"
           >
             Vaciar carrito


### PR DESCRIPTION
## Description
- Implement WhatsApp floating button with tooltip
- Add WhatsApp button to main and account layouts
- Replace hero section with optimized banner images
- Refactor sidebar menu items with readiness indicators
- Clean up router configuration and imports
- Improve cart page button logic and styling

### WhatsApp Button
<img width="1500" height="755" alt="image" src="https://github.com/user-attachments/assets/3605a97e-6aca-4a5f-bcc5-68a03aa83337" />

### Hero section banner
<img width="1504" height="617" alt="image" src="https://github.com/user-attachments/assets/3ac3b718-a3b8-47d1-b406-85c77e7650c1" />

## Note
- Desktop banner -> 1920x500
- Mobile banner   -> 1080x1350