### PR TITLE
feat(orders): add payment receipt upload functionality

### DIFF
--- a/src/actions/orders/index.ts
+++ b/src/actions/orders/index.ts
@@ -1,8 +1,8 @@
 import axios from 'axios'
 import { apiWithCredentials } from '../api'
-import { OrderCreateSchema } from '@/schemas/orders'
+import { OrderCreateSchema, OrderPaymentSchema } from '@/schemas/orders'
 import z from 'zod'
-import { Order, OrderResponse } from '@/types/order'
+import { Order, OrderPaymentResponse, OrderResponse } from '@/types/order'
 
 export const createOrder = async ({
   newData,
@@ -42,5 +42,34 @@ export const getAllOrders = async (): Promise<Order[]> => {
       return error.response?.data || { error: 'An unknown error occurred' }
     }
     throw new Error('An unknown error occurred')
+  }
+}
+
+export const registerPayment = async ({
+  userId,
+  orderId,
+  newData,
+}: {
+  userId: string
+  orderId: string
+  newData: z.infer<typeof OrderPaymentSchema>
+}): Promise<OrderPaymentResponse> => {
+  try {
+    const formData = new FormData()
+    formData.append('receipt', newData.receipt)
+    const { data } = await apiWithCredentials.post<OrderPaymentResponse>(
+      `/orders/${userId}/${orderId}`,
+      formData,
+      {
+        headers: { 'Content-Type': 'multipart/form-data' },
+      }
+    )
+    return data
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      const errorData = error.response?.data || { error: 'Ocurrió un error desconocido' }
+      throw new Error(errorData.error ?? 'Ocurrió un error desconocido')
+    }
+    throw new Error('Ocurrió un error desconocido')
   }
 }

--- a/src/hooks/orders/useCreateOrder.tsx
+++ b/src/hooks/orders/useCreateOrder.tsx
@@ -1,6 +1,6 @@
 import { createOrder } from '@/actions/orders'
 import { OrderCreateSchema } from '@/schemas/orders'
-import { Order, OrderStatus, PaymentStatus } from '@/types/order'
+import { Order, OrderStatus } from '@/types/order'
 import { ShippingAddress } from '@/types/shippingAddress'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { z } from 'zod'
@@ -17,7 +17,6 @@ const getOptimisticOrder = (
     shippingId: newData.shippingAddressId,
     couponId: sharedId,
     status: OrderStatus.PENDING,
-    paymentStatus: PaymentStatus.PENDING,
     updatedAt: new Date().toISOString(),
     createdAt: new Date().toISOString(),
     tax: newData.tax.toString(),

--- a/src/hooks/orders/useCreatePayment.tsx
+++ b/src/hooks/orders/useCreatePayment.tsx
@@ -1,0 +1,57 @@
+import { registerPayment } from '@/actions/orders'
+import { Order, OrderPayment, PaymentStatus } from '@/types/order'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+interface Props {
+  order: Order
+  userId: string
+}
+
+function useCreatePayment({ order, userId }: Props) {
+  const queryClient = useQueryClient()
+
+  const createPaymentMutation = useMutation({
+    mutationFn: registerPayment,
+    onMutate: ({ newData }) => {
+      const previousOrders = queryClient.getQueryData<Order[]>(['orders', userId])
+      const optimisticPayment: OrderPayment = {
+        id: `temp-${crypto.randomUUID()}`,
+        orderId: order.id,
+        status: PaymentStatus.PENDING,
+        receipt: URL.createObjectURL(newData.receipt),
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      }
+      const optimisticOrder: Order = {
+        ...order,
+        payment: optimisticPayment,
+      }
+
+      queryClient.setQueryData<Order[]>(['orders', userId], (oldOrders) => {
+        if (!oldOrders) return [optimisticOrder]
+        return oldOrders.map((cachedOrder) =>
+          cachedOrder.id === order.id ? optimisticOrder : cachedOrder
+        )
+      })
+
+      return { previousOrders, optimisticOrder }
+    },
+    onSuccess: ({ payment: newPayment }, _variables, { optimisticOrder }) => {
+      queryClient.setQueryData<Order[]>(['orders', userId], (oldOrders) => {
+        if (!oldOrders) return [optimisticOrder]
+        return oldOrders.map((cachedOrder) =>
+          cachedOrder.id === optimisticOrder.id ? { ...order, payment: newPayment } : cachedOrder
+        )
+      })
+    },
+    onError: (_error, _variables, context) => {
+      if (context?.previousOrders) {
+        queryClient.setQueryData<Order[]>(['orders', userId], context.previousOrders)
+      }
+    },
+  })
+
+  return { createPaymentMutation }
+}
+
+export default useCreatePayment

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,7 +4,7 @@ import { twMerge } from 'tailwind-merge'
 import ProductImagePlaceholder from '@/assets/images/productImagePlaceholder.png'
 import { ProductImage } from '@/types/product/images'
 
-const spaceBaseUrl = import.meta.env.VITE_AWS_SPACE_BASE_URL + '/'
+export const spaceBaseUrl = import.meta.env.VITE_AWS_SPACE_BASE_URL + '/'
 export const productImagePlaceholder = ProductImagePlaceholder
 
 export function cn(...inputs: ClassValue[]) {

--- a/src/pages/dashboard/products/images/index.tsx
+++ b/src/pages/dashboard/products/images/index.tsx
@@ -30,9 +30,7 @@ import useDeleteProductImage from '@/hooks/products/images/useDeleteProductImage
 import { Loader } from '@/components/ui/loader'
 import useReorderProductImages from '@/hooks/products/images/useReorderProductImages'
 import { Badge } from '@/components/ui/badge'
-import { productImagePlaceholder } from '@/lib/utils'
-
-const spaceBaseUrl = import.meta.env.VITE_AWS_SPACE_BASE_URL + '/'
+import { productImagePlaceholder, spaceBaseUrl } from '@/lib/utils'
 
 export function ReorderLoader() {
   return (

--- a/src/pages/orders/UploadReceipt.tsx
+++ b/src/pages/orders/UploadReceipt.tsx
@@ -1,0 +1,157 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog'
+import { Form, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { SubmitHandler, useForm } from 'react-hook-form'
+import { z } from 'zod'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useRef, useState } from 'react'
+import { OrderPaymentSchema } from '@/schemas/orders'
+import { EditIcon, UploadIcon } from 'lucide-react'
+import { Loader } from '@/components/ui/loader'
+import useCreatePayment from '@/hooks/orders/useCreatePayment'
+import { Order } from '@/types/order'
+import { toast } from 'sonner'
+
+interface Props {
+  order: Order
+  userId: string
+}
+
+function UploadReceipt({ order, userId }: Props) {
+  const [isOpen, setIsOpen] = useState(false)
+  const [selectedFile, setSelectedFile] = useState<File>()
+  const fileInputRef = useRef<HTMLInputElement | null>(null)
+  const { createPaymentMutation } = useCreatePayment({ order, userId })
+
+  const form = useForm<z.infer<typeof OrderPaymentSchema>>({
+    resolver: zodResolver(OrderPaymentSchema),
+    defaultValues: {
+      receipt: undefined,
+    },
+  })
+
+  const handleFilesChange = (file: File) => {
+    setSelectedFile(file)
+    form.setValue('receipt', file, { shouldValidate: true })
+  }
+
+  const onSubmit: SubmitHandler<z.infer<typeof OrderPaymentSchema>> = async (data) => {
+    setIsOpen(false)
+    createPaymentMutation.mutate(
+      { orderId: order.id, newData: data, userId },
+      {
+        onSuccess: ({ message }) => {
+          toast.success(message)
+          form.reset({ receipt: undefined })
+          setSelectedFile(undefined)
+        },
+        onError: (err) => {
+          setIsOpen(true)
+          const errorMsg = () => {
+            if (err instanceof Error) return err.message
+            return 'Ocurrió un error. Por favor intenta de nuevo.'
+          }
+          toast.error(errorMsg())
+        },
+      }
+    )
+  }
+
+  return (
+    <Dialog open={isOpen} onOpenChange={setIsOpen}>
+      <DialogTrigger asChild>
+        <Button variant="outline" size="sm">
+          <UploadIcon className="h-4 w-4 mr-1" />
+          Subir comprobante de pago
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Cargar comprobante</DialogTitle>
+          <DialogDescription>Estás a punto de subir el comprobante de compra</DialogDescription>
+        </DialogHeader>
+        <Form {...form}>
+          <form className="space-y-4" onSubmit={form.handleSubmit(onSubmit)}>
+            <FormField
+              control={form.control}
+              name="receipt"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel
+                    htmlFor="receipt"
+                    className="border p-4 rounded-lg font-serif cursor-pointer"
+                  >
+                    Cargar comprobante
+                    {selectedFile && <span className="text-blue-500">{selectedFile.name}</span>}
+                  </FormLabel>
+                  <Input
+                    id="receipt"
+                    type="file"
+                    accept="image/jpeg, image/jpg, image/png"
+                    placeholder="Por favor carga el comprobante de pago"
+                    onChange={(e) => {
+                      const file = e.target.files?.[0]
+                      if (file) {
+                        handleFilesChange(file)
+                        return e
+                      }
+                    }}
+                    onBlur={field.onBlur}
+                    name={field.name}
+                    ref={fileInputRef}
+                    className="sr-only"
+                  />
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {selectedFile && (
+              <div className="flex justify-center gap-4 p-4 rounded-lg border-3 border-dashed w-fit mx-auto">
+                <div key={selectedFile.size} className="relative group">
+                  <img
+                    src={URL.createObjectURL(selectedFile)}
+                    alt={`preview-${selectedFile.size}`}
+                    width={200}
+                    className="rounded-md object-cover w-full h-full border"
+                    loading="lazy"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => fileInputRef.current?.click()}
+                    className="absolute top-1 right-1 bg-black/50 hover:bg-black text-white rounded-full p-1 transition cursor-pointer"
+                    title="Eliminar imagen"
+                  >
+                    <EditIcon size={16} />
+                  </button>
+                </div>
+              </div>
+            )}
+
+            <Button
+              size={'lg'}
+              className={
+                'w-full uppercase font-serif ' +
+                (!form.formState.isValid ? 'cursor-not-allowed' : 'cursor-pointer')
+              }
+              type="submit"
+              disabled={!form.formState.isValid}
+            >
+              {form.formState.isLoading ? <Loader size="sm" variant="spinner" /> : 'Guardar'}
+            </Button>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export default UploadReceipt

--- a/src/pages/orders/index.tsx
+++ b/src/pages/orders/index.tsx
@@ -4,14 +4,21 @@ import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Loader } from '@/components/ui/loader'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { OrderItem, OrderStatus, orderStatusConfig, PaymentStatus } from '@/types/order'
+import {
+  OrderItem,
+  OrderStatus,
+  orderStatusConfig,
+  PaymentStatus,
+  paymentStatusConfig,
+} from '@/types/order'
 import { useState } from 'react'
 import { Separator } from '@/components/ui/separator'
-import { ChevronDown, ChevronUp, UploadIcon } from 'lucide-react'
-import { getLocalDateTime, pluralize } from '@/lib/utils'
+import { ChevronDown, ChevronUp, ExternalLinkIcon } from 'lucide-react'
+import { getLocalDateTime, pluralize, spaceBaseUrl } from '@/lib/utils'
 import useUserOrders from '@/hooks/orders/useUserOrders'
 import { useAuthStore } from '@/store/auth/useAuthStore'
 import ProductImage from '@/components/pages/products/ProductImage'
+import UploadReceipt from './UploadReceipt'
 
 function RenderOrderItem({ item }: { item: OrderItem }) {
   return (
@@ -50,161 +57,190 @@ function UserOrdersPage() {
           </div>
         )}
         {useOrdersQuery.isSuccess && useOrdersQuery.data.length ? (
-          <div className="flex flex-col gap-4">
-            {useOrdersQuery.data.map((order) => {
-              const isExpanded = expandedOrders.includes(order.id)
-              const OrderIcon = orderStatusConfig[order.status].icon
-              return (
-                <Card key={order.id} className="overflow-hidden">
-                  <CardHeader className="pb-4">
-                    <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
-                      <div className="flex items-center gap-4">
-                        <div>
-                          <CardTitle className="text-lg">{order.id}</CardTitle>
-                          <p className="text-sm text-muted-foreground">
-                            Creado el: {getLocalDateTime(order.createdAt, ['es-ve'])}
-                          </p>
-                        </div>
-                        <Badge className={`${orderStatusConfig[order.status].color} border`}>
-                          <OrderIcon className="h-4 w-4 mr-1" />
-                          {orderStatusConfig[order.status].label}
-                        </Badge>
-                      </div>
-
-                      <div className="flex items-center gap-2">
-                        <div className="text-right">
-                          <p className="font-semibold">${order.total}</p>
-                          <p className="text-sm text-muted-foreground">
-                            {order.items.length} {pluralize('producto', order.items, 's')}
-                          </p>
-                        </div>
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          onClick={() => toggleOrderExpansion(order.id)}
-                        >
-                          {isExpanded ? (
-                            <ChevronUp className="h-4 w-4" />
-                          ) : (
-                            <ChevronDown className="h-4 w-4" />
-                          )}
-                        </Button>
-                      </div>
-                    </div>
-                  </CardHeader>
-
-                  {/* Order Items Preview */}
-                  <CardContent className="pt-0">
-                    <div className="flex items-center gap-2 mb-4">
-                      {order.items.slice(0, 3).map((item, index) => (
-                        <div key={item.id} className="relative">
-                          <figure className="w-[40px] h-[40px] overflow-hidden rounded-md">
-                            <ProductImage product={item.product} className="w-full h-full" />
-                          </figure>
-                          {index === 2 && order.items.length > 3 && (
-                            <div className="absolute inset-0 bg-black/50 rounded-md flex items-center justify-center">
-                              <span className="text-white text-xs font-medium">
-                                +{order.items.length - 3}
-                              </span>
-                            </div>
-                          )}
-                        </div>
-                      ))}
-                      <div className="flex-1">
-                        <p className="text-sm font-medium">
-                          {order.items[0].product.name}
-                          {order.items.length > 1 &&
-                            ` y ${pluralize('otro', order.items.length - 1, 's')} ${pluralize(
-                              'producto',
-                              order.items.length - 1,
-                              's'
-                            )}`}
-                        </p>
-                      </div>
-                    </div>
-
-                    {/* Expanded Order Details */}
-                    {isExpanded && (
-                      <div className="space-y-4 border-t pt-4">
-                        {/* All Items */}
-                        <div className="space-y-3">
-                          <h4 className="font-medium">Productos</h4>
-                          {order.items.map((item) => (
-                            <RenderOrderItem key={item.id} item={item} />
-                          ))}
-                        </div>
-
-                        <Separator />
-
-                        {/* Order Summary */}
-                        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <section>
+            <div className="flex gap-4 items-center justify-center my-8">
+              {Object.entries(PaymentStatus).map((statusElement) => {
+                const StatusIcon = paymentStatusConfig[statusElement[1]].icon
+                return (
+                  <Badge
+                    key={statusElement[0]}
+                    className={`${paymentStatusConfig[statusElement[1]].color} border`}
+                  >
+                    <StatusIcon className="h-4 w-4 mr-1" />
+                    {paymentStatusConfig[statusElement[1]].label}
+                  </Badge>
+                )
+              })}
+            </div>
+            <div className="flex flex-col gap-4">
+              {useOrdersQuery.data.map((order) => {
+                const isExpanded = expandedOrders.includes(order.id)
+                const OrderIcon = orderStatusConfig[order.status].icon
+                return (
+                  <Card key={order.id} className="overflow-hidden">
+                    <CardHeader className="pb-4">
+                      <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+                        <div className="flex items-center gap-4">
                           <div>
-                            <h4 className="font-medium mb-2">Dirección de envío</h4>
-                            <div className="text-sm text-muted-foreground space-y-1">
-                              <p>{order.shipping.alias}</p>
-                              <p>
-                                {order.shipping.name} {order.shipping.lastName}
-                              </p>
-                              <p>{order.shipping.address_line_1}</p>
-                              <div className="flex gap-2">
-                                <Badge variant={'outline'}>{order.shipping.city}</Badge>
-                                {'>'}
-                                <Badge variant={'secondary'}>{order.shipping.state}</Badge>
-                                {'>'}
-                                <Badge>{order.shipping.country}</Badge>
+                            <CardTitle className="text-lg">{order.id}</CardTitle>
+                            <p className="text-sm text-muted-foreground">
+                              Creado el: {getLocalDateTime(order.createdAt, ['es-ve'])}
+                            </p>
+                          </div>
+                          <Badge className={`${orderStatusConfig[order.status].color} border`}>
+                            <OrderIcon className="h-4 w-4 mr-1" />
+                            {orderStatusConfig[order.status].label}
+                          </Badge>
+                        </div>
+
+                        <div className="flex items-center gap-2">
+                          <div className="text-right">
+                            <p className="font-semibold">${order.total}</p>
+                            <p className="text-sm text-muted-foreground">
+                              {order.items.length} {pluralize('producto', order.items, 's')}
+                            </p>
+                          </div>
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => toggleOrderExpansion(order.id)}
+                          >
+                            {isExpanded ? (
+                              <ChevronUp className="h-4 w-4" />
+                            ) : (
+                              <ChevronDown className="h-4 w-4" />
+                            )}
+                          </Button>
+                        </div>
+                      </div>
+                    </CardHeader>
+
+                    {/* Order Items Preview */}
+                    <CardContent className="pt-0">
+                      <div className="flex items-center gap-2 mb-4">
+                        {order.items.slice(0, 3).map((item, index) => (
+                          <div key={item.id} className="relative">
+                            <figure className="w-[40px] h-[40px] overflow-hidden rounded-md">
+                              <ProductImage product={item.product} className="w-full h-full" />
+                            </figure>
+                            {index === 2 && order.items.length > 3 && (
+                              <div className="absolute inset-0 bg-black/50 rounded-md flex items-center justify-center">
+                                <span className="text-white text-xs font-medium">
+                                  +{order.items.length - 3}
+                                </span>
                               </div>
-                            </div>
+                            )}
+                          </div>
+                        ))}
+                        <div className="flex-1">
+                          <p className="text-sm font-medium">
+                            {order.items[0].product.name}
+                            {order.items.length > 1 &&
+                              ` y ${pluralize('otro', order.items.length - 1, 's')} ${pluralize(
+                                'producto',
+                                order.items.length - 1,
+                                's'
+                              )}`}
+                          </p>
+                        </div>
+                      </div>
+
+                      {/* Expanded Order Details */}
+                      {isExpanded && (
+                        <div className="space-y-4 border-t pt-4">
+                          {/* All Items */}
+                          <div className="space-y-3">
+                            <h4 className="font-medium">Productos</h4>
+                            {order.items.map((item) => (
+                              <RenderOrderItem key={item.id} item={item} />
+                            ))}
                           </div>
 
-                          <div>
-                            <h4 className="font-medium mb-2">Resumen del pedido</h4>
-                            <div className="space-y-1 text-sm">
-                              <div className="flex justify-between">
-                                <span>Subtotal</span>
-                                <span>${order.subtotal}</span>
-                              </div>
-                              {Number(order.discount) > 0 && (
-                                <div className="flex justify-between text-green-600">
-                                  <span>Descuento</span>
-                                  <span>-${order.discount}</span>
+                          <Separator />
+
+                          {/* Order Summary */}
+                          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                            <div>
+                              <h4 className="font-medium mb-2">Dirección de envío</h4>
+                              <div className="text-sm text-muted-foreground space-y-1">
+                                <p>{order.shipping.alias}</p>
+                                <p>
+                                  {order.shipping.name} {order.shipping.lastName}
+                                </p>
+                                <p>{order.shipping.address_line_1}</p>
+                                <div className="flex gap-2">
+                                  <Badge variant={'outline'}>{order.shipping.city}</Badge>
+                                  {'>'}
+                                  <Badge variant={'secondary'}>{order.shipping.state}</Badge>
+                                  {'>'}
+                                  <Badge>{order.shipping.country}</Badge>
                                 </div>
-                              )}
-                              <div className="flex justify-between">
-                                <span>Impuesto</span>
-                                <span>${order.tax}</span>
                               </div>
-                              <Separator />
-                              <div className="flex justify-between font-medium">
-                                <span>Total</span>
-                                <span>${order.total}</span>
+                            </div>
+
+                            <div>
+                              <h4 className="font-medium mb-2">Resumen del pedido</h4>
+                              <div className="space-y-1 text-sm">
+                                <div className="flex justify-between">
+                                  <span>Subtotal</span>
+                                  <span>${order.subtotal}</span>
+                                </div>
+                                {Number(order.discount) > 0 && (
+                                  <div className="flex justify-between text-green-600">
+                                    <span>Descuento</span>
+                                    <span>-${order.discount}</span>
+                                  </div>
+                                )}
+                                <div className="flex justify-between">
+                                  <span>Impuesto</span>
+                                  <span>${order.tax}</span>
+                                </div>
+                                <Separator />
+                                <div className="flex justify-between font-medium">
+                                  <span>Total</span>
+                                  <span>${order.total}</span>
+                                </div>
                               </div>
                             </div>
                           </div>
-                        </div>
 
-                        <Separator />
+                          <Separator />
 
-                        {/* Order Actions */}
-                        <div className="flex flex-wrap gap-2">
-                          {order.paymentStatus === PaymentStatus.PENDING && (
-                            <Button variant="outline" size="sm">
-                              <UploadIcon className="h-4 w-4 mr-1" />
-                              Subir comprobante de pago
-                            </Button>
-                          )}
-                          {order.status === OrderStatus.DELIVERED && (
-                            <Button variant="outline" size="sm">
-                              Descargar factura
-                            </Button>
-                          )}
+                          {/* Order Actions */}
+                          <div className="flex flex-wrap gap-2">
+                            {!order.payment || !order.payment.receipt.length ? (
+                              <UploadReceipt
+                                order={order}
+                                userId={user?.id as string}
+                                key={'upload' + order.id}
+                              />
+                            ) : (
+                              <p className="flex items-center gap-1">
+                                <span>Pago cargado </span>
+                                <a
+                                  href={spaceBaseUrl + order.payment.receipt}
+                                  target="_blank"
+                                  rel="noopener noreferrer"
+                                  className="text-blue-500"
+                                >
+                                  <ExternalLinkIcon />
+                                </a>
+                              </p>
+                            )}
+                            {order.status === OrderStatus.DELIVERED && (
+                              <Button variant="outline" size="sm">
+                                Descargar factura
+                              </Button>
+                            )}
+                          </div>
                         </div>
-                      </div>
-                    )}
-                  </CardContent>
-                </Card>
-              )
-            })}
-          </div>
+                      )}
+                    </CardContent>
+                  </Card>
+                )
+              })}
+            </div>
+          </section>
         ) : (
           <p>No hay órdenes disponibles</p>
         )}

--- a/src/pages/products/Detail.tsx
+++ b/src/pages/products/Detail.tsx
@@ -25,7 +25,12 @@ import {
   Truck,
 } from 'lucide-react'
 import { useCartStore } from '@/store/cart/useCartStore'
-import { getFirstProductImage, parseFormattedText, productImagePlaceholder } from '@/lib/utils'
+import {
+  getFirstProductImage,
+  parseFormattedText,
+  productImagePlaceholder,
+  spaceBaseUrl,
+} from '@/lib/utils'
 import LiteYouTubeEmbed from 'react-lite-youtube-embed'
 import 'react-lite-youtube-embed/dist/LiteYouTubeEmbed.css'
 import Footer from '@/components/pages/Footer'
@@ -35,8 +40,6 @@ import useProduct from '@/hooks/products/useProduct'
 import { useProductActions } from '@/hooks/products/useActions'
 import ProductSkeleton from './ProductSkeleton'
 import ProductImage from '@/components/pages/products/ProductImage'
-
-const spaceBaseUrl = import.meta.env.VITE_AWS_SPACE_BASE_URL + '/'
 
 function ProductDetail() {
   const navigate = useNavigate()

--- a/src/schemas/orders/index.ts
+++ b/src/schemas/orders/index.ts
@@ -1,5 +1,8 @@
 import { z } from 'zod'
 
+const MAX_FILE_SIZE = 1024 * 1024 * 5
+const ACCEPTED_IMAGE_MIME_TYPES = ['image/jpeg', 'image/jpg', 'image/png']
+
 export const OrderCreateSchema = z.object({
   id: z.string().regex(/^ORD-\d{8}$/),
   couponId: z.string().optional(),
@@ -17,4 +20,15 @@ export const OrderCreateSchema = z.object({
   discount: z.number().nonnegative().default(0),
   tax: z.number().nonnegative().default(0),
   total: z.number().positive(),
+})
+
+export const OrderPaymentSchema = z.object({
+  receipt: z
+    .instanceof(File)
+    .refine((file) => file.size <= MAX_FILE_SIZE, {
+      message: 'La imagen debe ser de 5MB o menos',
+    })
+    .refine((file) => ACCEPTED_IMAGE_MIME_TYPES.includes(file.type), {
+      message: 'Solo los formatos .jpg, .jpeg y .png están permitidos.',
+    }),
 })

--- a/src/types/order/index.ts
+++ b/src/types/order/index.ts
@@ -7,6 +7,7 @@ export interface Order {
   userId: string
   shippingId: string
   couponId: string
+  orderPaymentId?: string
   tax: string
   subtotal: string
   discount: string
@@ -23,7 +24,7 @@ export interface Order {
   items: OrderItem[]
   shipping: Shipping
   status: OrderStatus
-  paymentStatus: PaymentStatus
+  payment?: OrderPayment
 }
 
 export interface OrderItem {
@@ -32,6 +33,15 @@ export interface OrderItem {
   quantity: number
   price: string
   product: Product
+}
+
+export interface OrderPayment {
+  id: string
+  orderId: string
+  status: PaymentStatus
+  receipt: string
+  createdAt: string
+  updatedAt: string
 }
 
 export interface Product {
@@ -156,5 +166,10 @@ export const paymentStatusConfig: Record<PaymentStatus, StatusConfig> = {
 
 export interface OrderResponse {
   order: Order
+  message: string
+}
+
+export interface OrderPaymentResponse {
+  payment: OrderPayment
   message: string
 }


### PR DESCRIPTION
## Description
- Add new `OrderPayment` type and schema for receipt validation.
- Implement `useCreatePayment` hook for optimistic UI updates.
- Create `UploadReceipt` component with file validation and preview.
- Update order page to show payment status and receipt upload.
- Export `spaceBaseUrl` from utils for consistent usage.