### PR TITLE
Implement order management features including pagination, filters, and admin updates

### DIFF
--- a/src/actions/orders/index.ts
+++ b/src/actions/orders/index.ts
@@ -1,8 +1,9 @@
 import axios from 'axios'
 import { apiWithCredentials } from '../api'
-import { OrderCreateSchema, OrderPaymentSchema } from '@/schemas/orders'
+import { OrderCreateSchema, OrderPaymentSchema, OrderAdminUpdateSchema } from '@/schemas/orders'
 import z from 'zod'
-import { Order, OrderPaymentResponse, OrderResponse } from '@/types/order'
+import { Order, OrderPaymentResponse, OrderResponse, OrdersPaginatedResponse } from '@/types/order'
+import { BaseFilterParams } from '@/types/shared'
 
 export const createOrder = async ({
   newData,
@@ -33,9 +34,19 @@ export const getOrdersByUser = async ({ userId }: { userId: string }): Promise<O
   }
 }
 
-export const getAllOrders = async (): Promise<Order[]> => {
+export const getAllOrders = async (params?: BaseFilterParams): Promise<OrdersPaginatedResponse> => {
+  const url = new URL(apiWithCredentials.defaults.baseURL?.toString() + '/orders' || '')
+
+  if (params) {
+    Object.entries(params).forEach(([key, value]) => {
+      if (value !== undefined && value !== null) {
+        url.searchParams.append(key, value.toString())
+      }
+    })
+  }
+
   try {
-    const { data } = await apiWithCredentials.get<Order[]>(`/orders`)
+    const { data } = await apiWithCredentials.get<OrdersPaginatedResponse>(url.toString())
     return data
   } catch (error) {
     if (axios.isAxiosError(error)) {
@@ -64,6 +75,25 @@ export const registerPayment = async ({
         headers: { 'Content-Type': 'multipart/form-data' },
       }
     )
+    return data
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      const errorData = error.response?.data || { error: 'Ocurrió un error desconocido' }
+      throw new Error(errorData.error ?? 'Ocurrió un error desconocido')
+    }
+    throw new Error('Ocurrió un error desconocido')
+  }
+}
+
+export const updateAdminOrder = async ({
+  id,
+  newData,
+}: {
+  id: string
+  newData: z.infer<typeof OrderAdminUpdateSchema>
+}): Promise<OrderResponse> => {
+  try {
+    const { data } = await apiWithCredentials.patch<OrderResponse>(`/orders/status/${id}`, newData)
     return data
   } catch (error) {
     if (axios.isAxiosError(error)) {

--- a/src/components/blocks/pagination/index.tsx
+++ b/src/components/blocks/pagination/index.tsx
@@ -1,6 +1,5 @@
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
-import { useProductFiltersStore } from '@/store/products/useProductFiltersStore'
 import { BasePaginatedResponse } from '@/types/shared'
 import { ChevronLeft, ChevronRight } from 'lucide-react'
 
@@ -10,6 +9,7 @@ type Props = {
   setPrevPage: () => void
   setNextPage: () => void
   setPageNumber: (page: number) => void
+  limit: number
 }
 
 const handleClick = (callback: (page?: number) => void) => {
@@ -45,8 +45,8 @@ function Pagination({
   setPrevPage,
   setNextPage,
   setPageNumber,
+  limit,
 }: Props) {
-  const { limit } = useProductFiltersStore()
   const { hasNextPage, hasPreviousPage, page: currentPage, totalPages } = paginationData
   const visiblePages = getVisiblePages(currentPage, totalPages)
 

--- a/src/hooks/orders/useAdminUpdateOrder.tsx
+++ b/src/hooks/orders/useAdminUpdateOrder.tsx
@@ -1,0 +1,42 @@
+import { updateAdminOrder } from '@/actions/orders'
+import { OrderAdminUpdateSchema } from '@/schemas/orders'
+import { Order } from '@/types/order'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import z from 'zod'
+
+function useUpdateAdminOrder() {
+  const queryClient = useQueryClient()
+  const updateAdminOrderMutation = useMutation({
+    mutationFn: ({
+      id,
+      newData,
+    }: {
+      id: string
+      newData: z.infer<typeof OrderAdminUpdateSchema>
+    }) => updateAdminOrder({ id, newData }),
+    onMutate: async ({ id, newData }) => {
+      await queryClient.cancelQueries({ queryKey: ['orders'] })
+
+      const previousOrders = queryClient.getQueryData<Order[]>(['orders'])
+
+      queryClient.setQueryData<Order[]>(['orders'], (oldOrders) => {
+        if (!oldOrders) return []
+
+        return oldOrders.map((order) => (order.id === id ? { ...order, ...newData } : order))
+      })
+      return { previousOrders }
+    },
+    onError: (_, __, context) => {
+      if (context?.previousOrders) {
+        queryClient.setQueryData(['orders'], context.previousOrders)
+      }
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ['orders'] })
+    },
+  })
+
+  return { updateAdminOrderMutation }
+}
+
+export default useUpdateAdminOrder

--- a/src/hooks/orders/useCreatePayment.tsx
+++ b/src/hooks/orders/useCreatePayment.tsx
@@ -17,7 +17,7 @@ function useCreatePayment({ order, userId }: Props) {
       const optimisticPayment: OrderPayment = {
         id: `temp-${crypto.randomUUID()}`,
         orderId: order.id,
-        status: PaymentStatus.UNPAID,
+        status: PaymentStatus.PROCESSING,
         receipt: URL.createObjectURL(newData.receipt),
         createdAt: new Date().toISOString(),
         updatedAt: new Date().toISOString(),

--- a/src/hooks/orders/useOrderQueryKey.ts
+++ b/src/hooks/orders/useOrderQueryKey.ts
@@ -1,0 +1,15 @@
+import { useOrderFiltersStore } from '@/store/orders/useOrderFiltersStore'
+
+export function useOrdersQueryKey() {
+  const page = useOrderFiltersStore((state) => state.page)
+  const limit = useOrderFiltersStore((state) => state.limit)
+  const search = useOrderFiltersStore((state) => state.search)
+  return { page, limit, search }
+}
+
+export function useOrdersFilterSetters() {
+  const setPage = useOrderFiltersStore((state) => state.setPage)
+  const setLimit = useOrderFiltersStore((state) => state.setLimit)
+  const setSearch = useOrderFiltersStore((state) => state.setSearch)
+  return { setPage, setLimit, setSearch }
+}

--- a/src/hooks/orders/useOrders.tsx
+++ b/src/hooks/orders/useOrders.tsx
@@ -1,15 +1,39 @@
 import { getAllOrders } from '@/actions/orders'
 import { useQuery } from '@tanstack/react-query'
+import { useOrdersFilterSetters, useOrdersQueryKey } from './useOrderQueryKey'
 
 function useOrders() {
+  const filters = useOrdersQueryKey()
+  const { setPage } = useOrdersFilterSetters()
+
   const ordersQuery = useQuery({
-    queryKey: ['orders'],
-    queryFn: () => getAllOrders(),
+    queryKey: ['orders', filters],
+    queryFn: () => getAllOrders(filters),
     staleTime: 1000 * 60 * 60,
   })
 
+  const setPrevPage = () => {
+    if (filters.page === 1) return
+
+    setPage(Number(ordersQuery.data?.pagination.previousPage))
+  }
+
+  const setNextPage = () => {
+    if (!ordersQuery.data?.pagination.hasNextPage) return
+
+    setPage(Number(ordersQuery.data?.pagination.nextPage))
+  }
+
+  const setPageNumber = (page: number) => {
+    setPage(page)
+  }
+
   return {
     ordersQuery,
+    page: filters.page,
+    setPrevPage,
+    setNextPage,
+    setPageNumber,
   }
 }
 

--- a/src/lib/orderLimitOptions.ts
+++ b/src/lib/orderLimitOptions.ts
@@ -1,0 +1,18 @@
+export const limitOptions = [
+  {
+    label: '25',
+    value: '25',
+  },
+  {
+    label: '50',
+    value: '50',
+  },
+  {
+    label: '75',
+    value: '75',
+  },
+  {
+    label: 'Todos',
+    value: '0',
+  },
+]

--- a/src/pages/dashboard/index.tsx
+++ b/src/pages/dashboard/index.tsx
@@ -131,11 +131,11 @@ function DahsboardIndex() {
         <RenderCard label="Pedidos pendientes">
           <div>
             <div>
-              {ordersQuery.data?.filter((order) => order.status === OrderStatus.PENDING).length ||
-                0}
+              {ordersQuery.data?.objects.filter((order) => order.status === OrderStatus.PENDING)
+                .length || 0}
             </div>
             <div className="absolute bottom-4 right-4 text-2xl">
-              <span>Total: {ordersQuery.data?.length || 0}</span>
+              <span>Total: {ordersQuery.data?.objects.length || 0}</span>
             </div>
           </div>
         </RenderCard>

--- a/src/pages/dashboard/orders/Filters.tsx
+++ b/src/pages/dashboard/orders/Filters.tsx
@@ -1,0 +1,113 @@
+import { limitOptions } from '@/lib/orderLimitOptions'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { useOrderFiltersStore } from '@/store/orders/useOrderFiltersStore'
+import { FilterIcon, FilterXIcon, SearchIcon } from 'lucide-react'
+import { useEffect, useState } from 'react'
+import { toast } from 'sonner'
+import { useDebounce } from 'use-debounce'
+import { Button } from '@/components/ui/button'
+import useOrders from '@/hooks/orders/useOrders'
+
+function OrderFiltersDialog() {
+  const limit = useOrderFiltersStore((state) => state.limit)
+  const setLimit = useOrderFiltersStore((state) => state.setLimit)
+  const resetFilters = useOrderFiltersStore((state) => state.resetFilters)
+
+  const handleReset = () => {
+    resetFilters()
+    toast.info('Filtros reseteados')
+  }
+
+  return (
+    <Dialog
+      onOpenChange={(isOpen) => {
+        if (!isOpen) toast.success('Filtros aplicados')
+      }}
+    >
+      <DialogTrigger asChild>
+        <Button variant={'outline'}>
+          <FilterIcon />
+          <span>Filtros</span>
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Filtros</DialogTitle>
+          <DialogDescription>
+            Filtra los productos por categoría y por cantidad de productos por página.
+          </DialogDescription>
+        </DialogHeader>
+
+        <section className="flex flex-col gap-2">
+          <div>
+            <Select
+              value={limit.toString()}
+              defaultValue={limit.toString()}
+              onValueChange={(value) => setLimit(Number(value))}
+            >
+              <SelectTrigger className="w-full">
+                <SelectValue placeholder="Mostrar" />
+              </SelectTrigger>
+              <SelectContent>
+                {limitOptions.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    Mostrar {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <Button variant={'secondary'} className="mt-6" onClick={handleReset}>
+            <FilterXIcon />
+            <span>Limpiar filtros</span>
+          </Button>
+        </section>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function OrdersFilters() {
+  const [localSearch, setLocalSearch] = useState('')
+  const setSearch = useOrderFiltersStore((state) => state.setSearch)
+
+  const [debouncedSearch] = useDebounce(localSearch, 500)
+
+  useOrders()
+
+  useEffect(() => {
+    setSearch(debouncedSearch)
+  }, [debouncedSearch, setSearch])
+
+  return (
+    <div className="flex-1 flex flex-col md:flex-row gap-2">
+      <div className="relative w-full max-w-md">
+        <SearchIcon className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+        <Input
+          placeholder="Filtrar por nombre..."
+          value={localSearch}
+          onChange={(e) => setLocalSearch(e.target.value)}
+          className="pl-10"
+        />
+      </div>
+      <OrderFiltersDialog />
+    </div>
+  )
+}
+
+export default OrdersFilters

--- a/src/pages/dashboard/orders/UpdateStatus.tsx
+++ b/src/pages/dashboard/orders/UpdateStatus.tsx
@@ -1,0 +1,188 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { InfoIcon, ListTodoIcon } from 'lucide-react'
+import { SubmitHandler, useForm } from 'react-hook-form'
+import { z } from 'zod'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { toast } from 'sonner'
+import { useState } from 'react'
+import ErrorForm from '@/components/pages/ErrorForm'
+import { Loader } from '@/components/ui/loader'
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form'
+import { OrderAdminUpdateSchema } from '@/schemas/orders'
+import { Order, OrderStatusLabels, PaymentStatus, PaymentStatusLabels } from '@/types/order'
+import useUpdateAdminOrder from '@/hooks/orders/useAdminUpdateOrder'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { Alert, AlertTitle } from '@/components/ui/alert'
+
+interface Props {
+  order: Order
+}
+
+function OrderUpdateStatusPage({ order }: Props) {
+  const [isOpen, setIsOpen] = useState(false)
+  const initialData = {
+    orderStatus: order.status,
+    paymentStatus: order.payment?.status || PaymentStatus.UNPAID,
+  }
+
+  const form = useForm<z.infer<typeof OrderAdminUpdateSchema>>({
+    resolver: zodResolver(OrderAdminUpdateSchema),
+    defaultValues: initialData,
+  })
+
+  const { updateAdminOrderMutation } = useUpdateAdminOrder()
+
+  const onSubmit: SubmitHandler<z.infer<typeof OrderAdminUpdateSchema>> = async (newData) => {
+    setIsOpen(false)
+    updateAdminOrderMutation.mutate(
+      { id: order.id, newData },
+      {
+        onSuccess: ({ message }) => {
+          toast.success(message)
+          form.reset()
+        },
+        onError: (err) => {
+          setIsOpen(true)
+          const errorMsg = () => {
+            if (err instanceof Error) return err.message
+            return 'Ocurrió un error. Por favor intenta de nuevo.'
+          }
+          toast.error(errorMsg())
+        },
+      }
+    )
+  }
+
+  return (
+    <Dialog open={isOpen} onOpenChange={setIsOpen}>
+      <DialogTrigger asChild>
+        <Button size={'icon'} variant={'ghost'} className="cursor-pointer text-blue-500">
+          <ListTodoIcon />
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Actualizar estado de la orden</DialogTitle>
+          <DialogDescription>Estás a punto de actualizar el estado de esta orden</DialogDescription>
+        </DialogHeader>
+        <Form {...form}>
+          <form className="space-y-4" onSubmit={form.handleSubmit(onSubmit)}>
+            <FormField
+              control={form.control}
+              name="orderStatus"
+              render={({ field }) => (
+                <FormItem className="w-full flex-1">
+                  <FormLabel htmlFor="orderStatus">Estado de la órden</FormLabel>
+                  <FormControl id="orderStatus">
+                    <Select onValueChange={field.onChange} defaultValue={field.value}>
+                      <SelectTrigger id="orderStatus" className="w-full">
+                        <SelectValue placeholder="Selecciona un estado" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {Object.entries(OrderStatusLabels).map(([value, label]) => (
+                          <SelectItem key={value} value={value}>
+                            {label}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </FormControl>
+                  <FormDescription />
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {order.payment ? (
+              <FormField
+                control={form.control}
+                name="paymentStatus"
+                render={({ field }) => (
+                  <FormItem className="w-full flex-1">
+                    <FormLabel htmlFor="paymentStatus">Estado del pago</FormLabel>
+                    <FormControl id="paymentStatus">
+                      <Select onValueChange={field.onChange} defaultValue={field.value}>
+                        <SelectTrigger id="paymentStatus" className="w-full">
+                          <SelectValue placeholder="Selecciona un estado" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {Object.entries(PaymentStatusLabels).map(([value, label]) => (
+                            <SelectItem key={value} value={value}>
+                              {label}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </FormControl>
+                    <FormDescription />
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            ) : (
+              <Alert>
+                <InfoIcon />
+                <AlertTitle>No hay información de pago para esta orden.</AlertTitle>
+              </Alert>
+            )}
+
+            {updateAdminOrderMutation.isError && (
+              <ErrorForm message={updateAdminOrderMutation.error.message} />
+            )}
+
+            <div className="flex items-center gap-2 justify-end">
+              <Button
+                type="button"
+                variant={'secondary'}
+                className="flex-1 font-serif uppercase"
+                onClick={() => form.reset({ ...initialData })}
+              >
+                Restablecer
+              </Button>
+              <Button
+                className={
+                  'flex-1 font-serif uppercase ' +
+                  (updateAdminOrderMutation.isPending || !form.formState.isValid
+                    ? 'cursor-not-allowed'
+                    : 'cursor-pointer')
+                }
+                type="submit"
+                disabled={updateAdminOrderMutation.isPending || !form.formState.isValid}
+              >
+                {updateAdminOrderMutation.isPending ? (
+                  <Loader size="sm" variant="spinner" />
+                ) : (
+                  'Guardar'
+                )}
+              </Button>
+            </div>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export default OrderUpdateStatusPage

--- a/src/pages/dashboard/orders/index.tsx
+++ b/src/pages/dashboard/orders/index.tsx
@@ -1,5 +1,4 @@
 import { Badge } from '@/components/ui/badge'
-import { Button } from '@/components/ui/button'
 import { Loader } from '@/components/ui/loader'
 import {
   Table,
@@ -13,7 +12,10 @@ import {
 import useOrders from '@/hooks/orders/useOrders'
 import { getLocalDateTime } from '@/lib/utils'
 import { OrderPayment, orderStatusConfig, PaymentStatus, paymentStatusConfig } from '@/types/order'
-import { EditIcon } from 'lucide-react'
+import OrderUpdateStatusPage from './UpdateStatus'
+import OrdersFilters from './Filters'
+import Pagination from '@/components/blocks/pagination'
+import { useOrderFiltersStore } from '@/store/orders/useOrderFiltersStore'
 
 export const GetPaymentStatus = ({ payment }: { payment?: OrderPayment }) => {
   const paymentStatus = payment ? payment.status : PaymentStatus.UNPAID
@@ -36,9 +38,12 @@ export const GetPaymentStatus = ({ payment }: { payment?: OrderPayment }) => {
 }
 
 function OrdersPage() {
-  const { ordersQuery } = useOrders()
+  const { limit } = useOrderFiltersStore()
+  const { ordersQuery, setNextPage, setPrevPage, setPageNumber } = useOrders()
+
   return (
     <div>
+      <OrdersFilters />
       <Table className="my-4">
         <TableHeader>
           <TableRow>
@@ -62,8 +67,8 @@ function OrdersPage() {
                 </div>
               </TableCell>
             </TableRow>
-          ) : ordersQuery.data && ordersQuery.data.length > 0 ? (
-            ordersQuery.data.map((order) => {
+          ) : ordersQuery.isSuccess && ordersQuery.data.objects.length > 0 ? (
+            ordersQuery.data.objects.map((order) => {
               const OrderIcon = orderStatusConfig[order.status].icon
               return (
                 <TableRow key={order.id} className="font-serif">
@@ -81,7 +86,7 @@ function OrdersPage() {
                     {getLocalDateTime(order.createdAt, ['es-ve'])}
                   </TableCell>
                   <TableCell>
-                    {order.payment && <GetPaymentStatus payment={order.payment} />}
+                    <GetPaymentStatus payment={order.payment} />
                   </TableCell>
                   <TableCell>
                     <div className="flex gap-2 items-center">
@@ -93,22 +98,30 @@ function OrdersPage() {
                   </TableCell>
                   <TableCell>${order.total}</TableCell>
                   <TableCell>
-                    <Button size={'icon'} className="cursor-pointer">
-                      <EditIcon />
-                    </Button>
+                    <OrderUpdateStatusPage order={order} />
                   </TableCell>
                 </TableRow>
               )
             })
           ) : (
             <TableRow>
-              <TableCell colSpan={7} className="text-center">
+              <TableCell colSpan={8} className="text-center">
                 No existen ordenes
               </TableCell>
             </TableRow>
           )}
         </TableBody>
       </Table>
+      {ordersQuery.data && (
+        <Pagination
+          paginationData={ordersQuery.data.pagination}
+          currentItems={ordersQuery.data.objects.length}
+          setNextPage={setNextPage}
+          setPrevPage={setPrevPage}
+          setPageNumber={setPageNumber}
+          limit={limit}
+        />
+      )}
     </div>
   )
 }

--- a/src/pages/dashboard/products/ProductsTable.tsx
+++ b/src/pages/dashboard/products/ProductsTable.tsx
@@ -230,6 +230,7 @@ function ProductsTable({ isDraggable, setIsDraggable }: Props) {
           setNextPage={setNextPage}
           setPrevPage={setPrevPage}
           setPageNumber={setPageNumber}
+          limit={limit}
         />
       )}
     </div>

--- a/src/pages/dashboard/users/index.tsx
+++ b/src/pages/dashboard/users/index.tsx
@@ -24,6 +24,7 @@ import { useUserFiltersStore } from '@/store/users/useUserFiltersStore'
 function UsersDashboardPage() {
   const [data, setData] = useState<User[]>([])
 
+  const limit = useUserFiltersStore((state) => state.limit)
   const setLimit = useUserFiltersStore((state) => state.setLimit)
   const setSearch = useUserFiltersStore((state) => state.setSearch)
   const setIsActive = useUserFiltersStore((state) => state.setIsActive)
@@ -125,6 +126,7 @@ function UsersDashboardPage() {
           setNextPage={setNextPage}
           setPrevPage={setPrevPage}
           setPageNumber={setPageNumber}
+          limit={limit}
         />
       )}
     </>

--- a/src/pages/orders/OrderCard.tsx
+++ b/src/pages/orders/OrderCard.tsx
@@ -4,7 +4,7 @@ import { GetPaymentStatus } from '../dashboard/orders'
 import { Order, OrderItem, OrderStatus, orderStatusConfig } from '@/types/order'
 import { getLocalDateTime, pluralize, spaceBaseUrl } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
-import { ChevronDown, ChevronUp, ExternalLinkIcon, Undo2, XCircle } from 'lucide-react'
+import { ChevronDown, ChevronUp, Undo2, XCircle } from 'lucide-react'
 import ProductImage from '@/components/pages/products/ProductImage'
 import { Separator } from '@/components/ui/separator'
 import UploadReceipt from './UploadReceipt'
@@ -184,17 +184,19 @@ function OrderCard({ order, expandedOrderId, onToggle }: Props) {
                   key={'upload' + order.id}
                 />
               ) : (
-                <p className="flex items-center gap-1">
-                  <span>Pago cargado </span>
+                <Badge
+                  variant={'outline'}
+                  asChild
+                  className="py-2 px-4 flex items-center justify-center transition hover:bg-slate-100 dark:hover:bg-slate-900"
+                >
                   <a
                     href={spaceBaseUrl + order.payment.receipt}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="text-blue-500"
                   >
-                    <ExternalLinkIcon />
+                    Ver comprobante de pago
                   </a>
-                </p>
+                </Badge>
               )}
               {order.status === OrderStatus.DELIVERED && (
                 <Button variant="outline" size="sm">

--- a/src/pages/orders/OrderProgress.tsx
+++ b/src/pages/orders/OrderProgress.tsx
@@ -10,10 +10,9 @@ const OrderFlow = [
 
 export function OrderProgress({ status }: { status: OrderStatus }) {
   const currentIndex = OrderFlow.indexOf(status)
-  const className = `relative grid grid-cols-[repeat(${OrderFlow.length},minmax(0,1fr))] items-center justify-evenly w-full py-6`
 
   return (
-    <div className={className}>
+    <div className={`relative grid grid-cols-4 items-center justify-evenly w-full py-6`}>
       {/* Línea base (fondo) */}
       <div className="absolute left-0 right-0 top-1/2 h-[2px] bg-gray-200 -translate-y-1/2 z-0" />
 

--- a/src/pages/orders/UploadReceipt.tsx
+++ b/src/pages/orders/UploadReceipt.tsx
@@ -61,6 +61,10 @@ function UploadReceipt({ order, userId }: Props) {
           }
           toast.error(errorMsg())
         },
+        onSettled: () => {
+          form.reset({ receipt: undefined })
+          setSelectedFile(undefined)
+        },
       }
     )
   }

--- a/src/pages/products/index.tsx
+++ b/src/pages/products/index.tsx
@@ -13,8 +13,10 @@ import ExtendedTooltip from '@/components/blocks/ExtendedTooltip'
 import Filters from '@/components/pages/products/Filters'
 import { useIsMobile } from '@/hooks/use-mobile'
 import { useMetaTags } from '@/hooks/useSEO'
+import { useProductFiltersStore } from '@/store/products/useProductFiltersStore'
 
 function ProductsPage() {
+  const { limit } = useProductFiltersStore()
   const [viewMode, setViewMode] = useState<'grid' | 'list'>('grid')
 
   const isMobile = useIsMobile()
@@ -110,6 +112,7 @@ function ProductsPage() {
                 setNextPage={setNextPage}
                 setPrevPage={setPrevPage}
                 setPageNumber={setPageNumber}
+                limit={limit}
               />
             )}
           </main>

--- a/src/schemas/orders/index.ts
+++ b/src/schemas/orders/index.ts
@@ -1,3 +1,4 @@
+import { OrderStatus, PaymentStatus } from '@/types/order'
 import { z } from 'zod'
 
 const MAX_FILE_SIZE = 1024 * 1024 * 5
@@ -31,4 +32,9 @@ export const OrderPaymentSchema = z.object({
     .refine((file) => ACCEPTED_IMAGE_MIME_TYPES.includes(file.type), {
       message: 'Solo los formatos .jpg, .jpeg y .png están permitidos.',
     }),
+})
+
+export const OrderAdminUpdateSchema = z.object({
+  orderStatus: z.nativeEnum(OrderStatus).optional(),
+  paymentStatus: z.nativeEnum(PaymentStatus).optional(),
 })

--- a/src/store/orders/useOrderFiltersStore.ts
+++ b/src/store/orders/useOrderFiltersStore.ts
@@ -1,0 +1,24 @@
+import { create } from 'zustand'
+import { limitOptions } from '@/lib/orderLimitOptions'
+
+const initialLimit = Number(limitOptions[0].value)
+
+interface OrderFiltersState {
+  page: number
+  limit: number
+  search: string
+  setPage: (page: number) => void
+  setLimit: (limit: number) => void
+  setSearch: (search: string) => void
+  resetFilters: () => void
+}
+
+export const useOrderFiltersStore = create<OrderFiltersState>((set) => ({
+  page: 1,
+  limit: initialLimit,
+  search: '',
+  setPage: (page) => set({ page }),
+  setLimit: (limit) => set({ limit }),
+  setSearch: (search) => set({ search }),
+  resetFilters: () => set({ page: 1, limit: initialLimit, search: '' }),
+}))

--- a/src/types/order/index.ts
+++ b/src/types/order/index.ts
@@ -1,6 +1,7 @@
 import { Package, CreditCardIcon } from 'lucide-react'
 import { ProductImage } from '../product/images'
 import { User } from '../auth/user'
+import { BasePaginatedResponse } from '../shared'
 
 export interface Order {
   id: string
@@ -172,4 +173,9 @@ export interface OrderResponse {
 export interface OrderPaymentResponse {
   payment: OrderPayment
   message: string
+}
+
+export interface OrdersPaginatedResponse {
+  objects: Order[]
+  pagination: BasePaginatedResponse
 }


### PR DESCRIPTION
## Description

### High-level overview
- Adds full order management features to the admin/dashboard area:
  - Server-side paginated order fetching and client-side pagination UI.
  - Filters (limit and search) for orders with a local store.
  - Admin ability to update order status and payment status.
  - UX improvements in order list, order card, and receipt upload behavior.
- Introduces several new hooks, store, UI pages/components, and type/schema updates.

### Files added
- useAdminUpdateOrder.tsx — React Query mutation hook for admin order updates with optimistic updates and rollback.
- useOrderQueryKey.ts — Helpers to read/set order filters (page, limit, search) from store.
- orderLimitOptions.ts — Limit options used in filters (25, 50, 75, Todos).
- Filters.tsx — Filters UI with a dialog and search input using debounce; also integrates with orders hook to trigger fetches.
- UpdateStatus.tsx — Dialog form for admin to update order status and payment status (uses zod schema, react-hook-form, and mutation hook).
- useOrderFiltersStore.ts — Zustand store to keep page, limit, search and setters/resetters.

### Files modified
- index.ts
  - Accepts optional filter params and builds a URL with query params to fetch paginated orders.
  - Changes `getAllOrders` to return an `OrdersPaginatedResponse`.
  - Adds `updateAdminOrder` API call to PATCH order status at `/orders/status/:id`.
  - Imports new zod schema `OrderAdminUpdateSchema` and new types.

- index.tsx
  - Removed product filters dependency and added a `limit` prop.
  - Adapted to accept pagination data and control callbacks.

- useCreatePayment.tsx
  - Changes optimistic payment status from UNPAID to PROCESSING.

- useOrders.tsx
  - Now uses `useOrdersQueryKey` and `useOrdersFilterSetters`.
  - Query key includes filters and `getAllOrders` is passed filters.
  - Exposes pagination helpers: setPrevPage, setNextPage, setPageNumber and current page.

- index.tsx
  - Reworked orders table to consume paginated response shape (`objects` + `pagination`).
  - Adds `OrdersFilters` component above table.
  - Replaces inline edit button with `OrderUpdateStatusPage` dialog component.
  - Adds `Pagination` component under the table (passes pagination data, current items, callbacks and limit).
  - Adjusts columns and colspan to match new layout.

- ProductsTable.tsx
  - Passes `limit` down into existing pagination component (consistency).

- OrderCard.tsx
  - Replaces an external link icon with a styled `Badge` containing a textual "Ver comprobante de pago" link.
  - Removes the `ExternalLinkIcon` import.

- OrderProgress.tsx
  - Simplifies CSS grid definition to a fixed 4 columns (from dynamic repeat based on flow length).

- UploadReceipt.tsx
  - Resets the receipt form and clears selected file on mutation settle.

- index.ts
  - Imports `OrderStatus` and `PaymentStatus` enums.
  - Adds `OrderAdminUpdateSchema` with optional orderStatus and paymentStatus enums.

- index.ts
  - Adds `OrdersPaginatedResponse` type (objects + pagination).
  - Imports `BasePaginatedResponse` to type pagination.

### Key behavior changes and notes
- API: `getAllOrders` no longer returns a flat Order[]; it returns a paginated object (objects + pagination). Callers must handle the new shape.
- Pagination: Client now stores `page`, `limit`, and `search` in a Zustand store (`useOrderFiltersStore`) and uses them to build query keys and request params. The UI exposes limit selection and search box with debounce.
- Admin updates: Admins can update order and payment status using `UpdateStatus` dialog. The hook uses optimistic updates and rolls back on error, then invalidates queries on settle.
- Optimistic payment creation now sets optimistic payment status to PROCESSING (instead of UNPAID).
- UI: Orders list and cards were adapted to the new paginated shape; pagination component receives `limit` prop; table columns adjusted.
- Types and schemas updated accordingly (zod schema and TypeScript types).

### Potential follow-ups (observations)
- Ensure all places that previously used `getAllOrders()` and expected an array are updated to use `.objects` and `.pagination`. The commit updated the dashboard orders page, but other callers should be checked.
- The pagination component previously depended on product filters; it's now more generic — verify its usage across product pages still aligns with new prop signature.
- The change in `OrderProgress` grid from dynamic to fixed 4 columns may reduce flexibility if the order flow length changes; verify visually.
- Some imports (e.g., new `useOrderFiltersStore` usage) assume those files are properly exported/resolved by build tooling; run the app/tests to verify no type or import errors.

### Short one-line summary
Adds paginated order fetching, filter UI, admin order-status update flow (API + UI + optimistic updates), plus related type/schema and UI tweaks to support order management in the dashboard.

## Details
<img width="1537" height="799" alt="image" src="https://github.com/user-attachments/assets/aace7e84-652b-461f-a9bf-ce2facb832ee" />

<img width="1537" height="800" alt="image" src="https://github.com/user-attachments/assets/5de9f387-30c5-490c-845f-c84f040dc919" />

<img width="1538" height="800" alt="image" src="https://github.com/user-attachments/assets/cf1c4777-c07b-4536-886f-fcb78e11851e" />
